### PR TITLE
Update repository to use AIQA instead of Shortest

### DIFF
--- a/packages/shortest/README.md
+++ b/packages/shortest/README.md
@@ -1,4 +1,4 @@
-# Shortest
+# AIQA
 
 AI-powered natural language end-to-end testing framework.
 
@@ -11,28 +11,28 @@ AI-powered natural language end-to-end testing framework.
 
 ### Installation
 
-Use the `shortest init` command to streamline the setup process in a new or existing project.
+Use the `aiqa init` command to streamline the setup process in a new or existing project.
 
-The `shortest init` command will:
+The `aiqa init` command will:
 
 ```sh
-npx @antiwork/shortest init
+npx @antiwork/aiqa init
 ```
 
 This will:
 
-- Automatically install the `@antiwork/shortest` package as a dev dependency if it is not already installed
-- Create a default `shortest.config.ts` file with boilerplate configuration
+- Automatically install the `@antiwork/aiqa` package as a dev dependency if it is not already installed
+- Create a default `aiqa.config.ts` file with boilerplate configuration
 - Generate a `.env.local` file (unless present) with placeholders for required environment variables, such as
-  `SHORTEST_ANTHROPIC_API_KEY` or `ANTHROPIC_API_KEY`
-- Add `.env.local` and `.shortest/` to `.gitignore`
+  `AIQA_ANTHROPIC_API_KEY` or `ANTHROPIC_API_KEY`
+- Add `.env.local` and `.aiqa/` to `.gitignore`
 
 ### Quick start
 
-1. Determine your test entry and add your Anthropic API key in config file: `shortest.config.ts`
+1. Determine your test entry and add your Anthropic API key in config file: `aiqa.config.ts`
 
 ```typescript
-import type { ShortestConfig } from "@antiwork/shortest";
+import type { AIQAConfig } from "@antiwork/aiqa";
 
 export default {
   headless: false,
@@ -46,18 +46,18 @@ export default {
   ai: {
     provider: "anthropic",
   },
-} satisfies ShortestConfig;
+} satisfies AIQAConfig;
 ```
-The Anthropic API key defaults to `SHORTEST_ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEY` environment variables. Can be overwritten via `ai.config.apiKey`.
+The Anthropic API key defaults to `AIQA_ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEY` environment variables. Can be overwritten via `ai.config.apiKey`.
 
 Optionally, you can configure browser behavior using the `browser.contextOptions` property in your configuration file. This allows you to pass custom [Playwright browser context options](https://playwright.dev/docs/api/class-browser#browser-new-context).
 
 2. Create test files using the pattern specified in the config: `app/login.test.ts`
 
 ```typescript
-import { shortest } from "@antiwork/shortest";
+import { aiqa } from "@antiwork/aiqa";
 
-shortest("Login to the app using email and password", {
+aiqa("Login to the app using email and password", {
   username: process.env.GITHUB_USERNAME,
   password: process.env.GITHUB_PASSWORD,
 });
@@ -69,12 +69,12 @@ You can also use callback functions to add additional assertions and other logic
 execution in browser is completed.
 
 ```typescript
-import { shortest } from "@antiwork/shortest";
+import { aiqa } from "@antiwork/aiqa";
 import { db } from "@/lib/db/drizzle";
 import { users } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 
-shortest("Login to the app using username and password", {
+aiqa("Login to the app using username and password", {
   username: process.env.USERNAME,
   password: process.env.PASSWORD,
 }).after(async ({ page }) => {
@@ -103,16 +103,16 @@ shortest("Login to the app using username and password", {
 You can use lifecycle hooks to run code before and after the test.
 
 ```typescript
-import { shortest } from "@antiwork/shortest";
+import { aiqa } from "@antiwork/aiqa";
 
-shortest.beforeAll(async ({ page }) => {
+aiqa.beforeAll(async ({ page }) => {
   await clerkSetup({
     frontendApiUrl:
       process.env.PLAYWRIGHT_TEST_BASE_URL ?? "http://localhost:3000",
   });
 });
 
-shortest.beforeEach(async ({ page }) => {
+aiqa.beforeEach(async ({ page }) => {
   await clerk.signIn({
     page,
     signInParams: {
@@ -122,22 +122,22 @@ shortest.beforeEach(async ({ page }) => {
   });
 });
 
-shortest.afterEach(async ({ page }) => {
+aiqa.afterEach(async ({ page }) => {
   await page.close();
 });
 
-shortest.afterAll(async ({ page }) => {
+aiqa.afterAll(async ({ page }) => {
   await clerk.signOut({ page });
 });
 ```
 
 ### Chaining tests
 
-Shortest supports flexible test chaining patterns:
+AIQA supports flexible test chaining patterns:
 
 ```typescript
 // Sequential test chain
-shortest([
+aiqa([
   "user can login with email and password",
   "user can modify their account-level refund policy",
 ]);
@@ -148,16 +148,16 @@ const loginAsContractor = "login as contractor with valid credentials";
 const allAppActions = ["send invoice to company", "view invoices"];
 
 // Combine flows with spread operator
-shortest([loginAsLawyer, ...allAppActions]);
-shortest([loginAsContractor, ...allAppActions]);
+aiqa([loginAsLawyer, ...allAppActions]);
+aiqa([loginAsContractor, ...allAppActions]);
 ```
 
-Shortest's style allows non-engineers such as designers, marketers, and PMs to write tests. Here are some examples:
+AIQA's style allows non-engineers such as designers, marketers, and PMs to write tests. Here are some examples:
 
 ```typescript
-shortest("visit every page and ensure no typos");
-shortest("visit every page and ensure mobile layout isn't janky");
-shortest("visit every page and ensure dark mode is considered");
+aiqa("visit every page and ensure no typos");
+aiqa("visit every page and ensure mobile layout isn't janky");
+aiqa("visit every page and ensure dark mode is considered");
 ```
 
 ### API Testing
@@ -169,7 +169,7 @@ const req = new APIRequest({
   baseURL: API_BASE_URI,
 });
 
-shortest(
+aiqa(
   "Ensure the response contains only active users",
   req.fetch({
     url: "/users",
@@ -184,7 +184,7 @@ shortest(
 Or simply:
 
 ```typescript
-shortest(`
+aiqa(`
   Test the API GET endpoint ${API_BASE_URI}/users with query parameter { "active": true }
   Expect the response to contain only active users
 `);
@@ -193,28 +193,28 @@ shortest(`
 ### Running tests
 
 ```bash
-pnpm shortest                   # Run all tests
-pnpm shortest login.test.ts     # Run specific tests from a file
-pnpm shortest login.test.ts:23  # Run specific test from a file using a line number
-pnpm shortest --headless        # Run in headless mode using
+pnpm aiqa                   # Run all tests
+pnpm aiqa login.test.ts     # Run specific tests from a file
+pnpm aiqa login.test.ts:23  # Run specific test from a file using a line number
+pnpm aiqa --headless        # Run in headless mode using
 ```
 
 You can find example tests in the [`examples`](./examples) directory.
 
 ### GitHub 2FA login setup
 
-Shortest currently supports login using Github 2FA. For GitHub authentication tests:
+AIQA currently supports login using Github 2FA. For GitHub authentication tests:
 
 1. Go to your repository settings
 2. Navigate to "Password and Authentication"
 3. Click on "Authenticator App"
 4. Select "Use your authenticator app"
 5. Click "Setup key" to obtain the OTP secret
-6. Add the OTP secret to your `.env.local` file or use the Shortest CLI to add it
+6. Add the OTP secret to your `.env.local` file or use the AIQA CLI to add it
 7. Enter the 2FA code displayed in your terminal into Github's Authenticator setup page to complete the process
 
 ```bash
-shortest --github-code --secret=<OTP_SECRET>
+aiqa --github-code --secret=<OTP_SECRET>
 ```
 
 ### Environment setup
@@ -228,13 +228,13 @@ GITHUB_TOTP_SECRET=your_secret  # Only for GitHub auth tests
 
 ### CI setup
 
-You can run Shortest in your CI/CD pipeline by running tests in headless mode. Make sure to add your Anthropic API key to your CI/CD pipeline secrets.
+You can run AIQA in your CI/CD pipeline by running tests in headless mode. Make sure to add your Anthropic API key to your CI/CD pipeline secrets.
 
 ## Resources
 
-- Visit [GitHub](https://github.com/antiwork/shortest) for detailed docs
+- Visit [GitHub](https://github.com/antiwork/aiqa) for detailed docs
 - [Contributing guide](./CONTRIBUTING.md)
-- [Changelog](https://github.com/antiwork/shortest/releases)
+- [Changelog](https://github.com/antiwork/aiqa/releases)
 
 ### Prerequisites
 

--- a/packages/shortest/package.json
+++ b/packages/shortest/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@antiwork/shortest",
+  "name": "@antiwork/aiqa",
   "version": "0.4.9",
   "description": "AI-powered natural language end-to-end testing framework",
   "type": "module",
@@ -7,7 +7,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "shortest": "./dist/cli/bin.js"
+    "aiqa": "./dist/cli/bin.js"
   },
   "exports": {
     ".": {
@@ -19,7 +19,7 @@
   "files": [
     "dist",
     "dist/cli",
-    "src/shortest.config.ts.example"
+    "src/aiqa.config.ts.example"
   ],
   "scripts": {
     "build": "rimraf dist && pnpm build:types && pnpm build:js && pnpm build:cli",
@@ -36,7 +36,7 @@
     "test:unit": "npx vitest run",
     "test:unit:watch": "npx vitest --watch",
     "test:e2e": "node --import tsx --test tests/e2e/index.ts",
-    "cache:clear": "pnpm build && shortest cache clear --force-purge"
+    "cache:clear": "pnpm build && aiqa cache clear --force-purge"
   },
   "dependencies": {
     "@babel/code-frame": "^7.26.2",
@@ -85,9 +85,9 @@
   "author": "Antiwork",
   "license": "MIT",
   "repository": {
-    "directory": "packages/shortest",
+    "directory": "packages/aiqa",
     "type": "git",
-    "url": "https://github.com/antiwork/shortest"
+    "url": "https://github.com/antiwork/aiqa"
   },
   "keywords": [
     "testing",
@@ -98,9 +98,9 @@
     "playwright"
   ],
   "bugs": {
-    "url": "https://github.com/antiwork/shortest/issues"
+    "url": "https://github.com/antiwork/aiqa/issues"
   },
-  "homepage": "https://github.com/antiwork/shortest#readme",
+  "homepage": "https://github.com/antiwork/aiqa#readme",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/shortest/src/ai/client.test.ts
+++ b/packages/shortest/src/ai/client.test.ts
@@ -235,7 +235,7 @@ describe("AIClient", () => {
 
           await expect(client.runAction("test prompt")).rejects.toMatchObject({
             message: expectedMessage,
-            name: "ShortestError", // AIError gets converted to ShortestError by asShortestError
+            name: "AIQAError", // AIError gets converted to AIQAError by asAIQAError
             type: expectedType,
           });
         },

--- a/packages/shortest/src/cli/bin.ts
+++ b/packages/shortest/src/cli/bin.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import pc from "picocolors";
 import {
-  shortestCommand,
+  aiqaCommand,
   githubCodeCommand,
   initCommand,
   cacheCommands,
@@ -25,31 +25,31 @@ process.on("warning", (warning) => {
   console.warn(warning);
 });
 
-shortestCommand.addCommand(initCommand);
-initCommand.copyInheritedSettings(shortestCommand);
+aiqaCommand.addCommand(initCommand);
+initCommand.copyInheritedSettings(aiqaCommand);
 
-shortestCommand.addCommand(githubCodeCommand);
-githubCodeCommand.copyInheritedSettings(shortestCommand);
+aiqaCommand.addCommand(githubCodeCommand);
+githubCodeCommand.copyInheritedSettings(aiqaCommand);
 
-shortestCommand.addCommand(cacheCommands);
-cacheCommands.copyInheritedSettings(shortestCommand);
+aiqaCommand.addCommand(cacheCommands);
+cacheCommands.copyInheritedSettings(aiqaCommand);
 clearCommand.copyInheritedSettings(cacheCommands);
 
-shortestCommand.addCommand(detectFrameworkCommand);
-detectFrameworkCommand.copyInheritedSettings(shortestCommand);
+aiqaCommand.addCommand(detectFrameworkCommand);
+detectFrameworkCommand.copyInheritedSettings(aiqaCommand);
 
-shortestCommand.addCommand(analyzeCommand);
-analyzeCommand.copyInheritedSettings(shortestCommand);
+aiqaCommand.addCommand(analyzeCommand);
+analyzeCommand.copyInheritedSettings(aiqaCommand);
 
-shortestCommand.addCommand(planCommand);
-planCommand.copyInheritedSettings(shortestCommand);
+aiqaCommand.addCommand(planCommand);
+planCommand.copyInheritedSettings(aiqaCommand);
 
-shortestCommand.addCommand(generateCommand);
-generateCommand.copyInheritedSettings(shortestCommand);
+aiqaCommand.addCommand(generateCommand);
+generateCommand.copyInheritedSettings(aiqaCommand);
 
 const main = async () => {
   try {
-    await shortestCommand.parseAsync();
+    await aiqaCommand.parseAsync();
     process.exit(0);
   } catch (error) {
     const log = getLogger();

--- a/packages/shortest/src/cli/commands/init.ts
+++ b/packages/shortest/src/cli/commands/init.ts
@@ -35,18 +35,18 @@ import { EnvFile } from "@/utils/env-file";
 import { ShortestError } from "@/utils/errors";
 
 export const initCommand = new Command("init")
-  .description("Initialize Shortest in current directory")
+  .description("Initialize AIQA in current directory")
   .addHelpText(
     "after",
     `
 ${pc.bold("The command will:")}
-- Automatically install the @antiwork/shortest package as a dev dependency if it is not already installed
-- Create a default shortest.config.ts file with boilerplate configuration
+- Automatically install the @antiwork/aiqa package as a dev dependency if it is not already installed
+- Create a default aiqa.config.ts file with boilerplate configuration
 - Generate a ${ENV_LOCAL_FILENAME} file (unless present) with placeholders for required environment variables, such as ANTHROPIC_API_KEY
 - Add ${ENV_LOCAL_FILENAME} and ${DOT_SHORTEST_DIR_NAME} to .gitignore
 
 ${pc.bold("Documentation:")}
-  ${pc.cyan("https://github.com/antiwork/shortest")}
+  ${pc.cyan("https://github.com/antiwork/aiqa")}
 `,
   );
 
@@ -90,7 +90,7 @@ export const executeInitCommand = async () => {
             })),
       },
       {
-        title: "Install Shortest",
+        title: "Install AIQA",
         task: (_, task): Listr =>
           task.newListr(
             [
@@ -99,14 +99,14 @@ export const executeInitCommand = async () => {
                 task: async (ctx, task): Promise<void> => {
                   const packageJson = await getPackageJson();
                   ctx.alreadyInstalled = !!(
-                    packageJson?.dependencies?.["@antiwork/shortest"] ||
-                    packageJson?.devDependencies?.["@antiwork/shortest"]
+                    packageJson?.dependencies?.["@antiwork/aiqa"] ||
+                    packageJson?.devDependencies?.["@antiwork/aiqa"]
                   );
                   if (ctx.alreadyInstalled) {
-                    task.title = `Shortest is already installed`;
+                    task.title = `AIQA is already installed`;
                   } else {
                     task.title =
-                      "Shortest is not installed, starting installation.";
+                      "AIQA is not installed, starting installation.";
                   }
                 },
               },
@@ -174,10 +174,10 @@ export const executeInitCommand = async () => {
                                             : "Use the default API key name",
                                         },
                                         {
-                                          name: "SHORTEST_ANTHROPIC_API_KEY",
-                                          value: "SHORTEST_ANTHROPIC_API_KEY",
+                                          name: "AIQA_ANTHROPIC_API_KEY",
+                                          value: "AIQA_ANTHROPIC_API_KEY",
                                           description:
-                                            "Use a dedicated API key for Shortest",
+                                            "Use a dedicated API key for AIQA",
                                         },
                                       ],
                                     })),
@@ -220,7 +220,7 @@ export const executeInitCommand = async () => {
                         },
                       },
                       {
-                        title: "Adding Shortest login credentials for testing",
+                        title: "Adding AIQA login credentials for testing",
                         task: async (_, task): Promise<Listr> => {
                           await Promise.resolve();
                           return task.newListr([
@@ -230,21 +230,21 @@ export const executeInitCommand = async () => {
                                 (ctx.shortestLoginEmail = await task
                                   .prompt(ListrInquirerPromptAdapter)
                                   .run(input, {
-                                    message: `Enter value for SHORTEST_LOGIN_EMAIL. Skip if the application does not require authentication.`,
+                                    message: `Enter value for AIQA_LOGIN_EMAIL. Skip if the application does not require authentication.`,
                                   })),
                             },
                             {
-                              title: "Saving SHORTEST_LOGIN_EMAIL key",
+                              title: "Saving AIQA_LOGIN_EMAIL key",
                               skip: (ctx): boolean => !ctx.shortestLoginEmail,
                               task: async (ctx, task) => {
                                 const keyAdded = await ctx.envFile.add({
-                                  key: "SHORTEST_LOGIN_EMAIL",
+                                  key: "AIQA_LOGIN_EMAIL",
                                   value: ctx.shortestLoginEmail,
                                 });
                                 if (keyAdded) {
-                                  task.title = `SHORTEST_LOGIN_EMAIL added`;
+                                  task.title = `AIQA_LOGIN_EMAIL added`;
                                 } else {
-                                  task.title = `SHORTEST_LOGIN_EMAIL already exists, skipped`;
+                                  task.title = `AIQA_LOGIN_EMAIL already exists, skipped`;
                                 }
                               },
                             },
@@ -255,22 +255,22 @@ export const executeInitCommand = async () => {
                                 (ctx.shortestLoginPassword = await task
                                   .prompt(ListrInquirerPromptAdapter)
                                   .run(input, {
-                                    message: `Enter value for SHORTEST_LOGIN_PASSWORD`,
+                                    message: `Enter value for AIQA_LOGIN_PASSWORD`,
                                   })),
                             },
                             {
-                              title: "Saving SHORTEST_LOGIN_PASSWORD key",
+                              title: "Saving AIQA_LOGIN_PASSWORD key",
                               skip: (ctx): boolean =>
                                 !ctx.shortestLoginPassword,
                               task: async (ctx, task) => {
                                 const keyAdded = await ctx.envFile.add({
-                                  key: "SHORTEST_LOGIN_PASSWORD",
+                                  key: "AIQA_LOGIN_PASSWORD",
                                   value: ctx.shortestLoginPassword,
                                 });
                                 if (keyAdded) {
-                                  task.title = `SHORTEST_LOGIN_PASSWORD added`;
+                                  task.title = `AIQA_LOGIN_PASSWORD added`;
                                 } else {
-                                  task.title = `SHORTEST_LOGIN_PASSWORD already exists, skipped`;
+                                  task.title = `AIQA_LOGIN_PASSWORD already exists, skipped`;
                                 }
                               },
                             },
@@ -290,7 +290,7 @@ export const executeInitCommand = async () => {
                 enabled: (ctx): boolean => !ctx.alreadyInstalled,
                 task: async (ctx, task) => {
                   const testPattern = ctx.generateSampleTestFile
-                    ? "shortest/**/*.test.ts"
+                    ? "aiqa/**/*.test.ts"
                     : testPatternSchema._def.defaultValue();
                   await generateConfigFile(
                     join(process.cwd(), CONFIG_FILENAME),
@@ -431,11 +431,11 @@ export const executeInitCommand = async () => {
     await tasks.run();
     if (tasks.ctx.generateSampleTestFile) {
       console.log(pc.green("\nSetup complete!"));
-      console.log("Run tests with: npx/pnpm shortest");
+      console.log("Run tests with: npx/pnpm aiqa");
     } else {
       console.log(pc.green("\nInitialization complete! Next steps:"));
       console.log("1. Create your first test file: example.test.ts");
-      console.log("2. Run tests with: npx/pnpm shortest example.test.ts");
+      console.log("2. Run tests with: npx/pnpm aiqa example.test.ts");
     }
   } catch (error) {
     console.error(pc.red("Initialization failed"));
@@ -464,7 +464,7 @@ export const getInstallCmd = async () => {
   const command = resolveCommand(
     packageManager.agent,
     packageManager.agent === "yarn" ? "add" : "install",
-    ["@antiwork/shortest", "--save-dev"],
+    ["@antiwork/aiqa", "--save-dev"],
   );
 
   if (!command) {


### PR DESCRIPTION
Update repository to use AIQA framework instead of Shortest.

* **README.md**: Update references from `Shortest` to `AIQA`, including installation instructions, usage examples, and commands.
* **bin.ts**: Replace `shortestCommand` with `aiqaCommand` and update related command references.
* **index.ts**: Update logic to execute tests using `AIQA`, including error handling and test file parsing.
* **init.ts**: Update initialization steps to set up `AIQA`, including environment variable names and installation messages.
* **client.test.ts**: Update error name from `ShortestError` to `AIQAError`.
* **package.json**: Change package name from `@antiwork/shortest` to `@antiwork/aiqa` and update related URLs and commands.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HanifKarimi/AIQA/pull/1?shareId=a2a223da-489c-491f-a95c-01a379941a41).